### PR TITLE
Add daily challenge and persistent progress

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,10 +13,10 @@ Open `index.html` in a modern browser. No server is required.
 - `src/utils/Theme.js` – light/dark/high-contrast theme manager.
 - `src/core/Solver.js` – Hierholzer-based solver used for hints.
 - Basic modal UI for level completion and game over.
-- Four modes: Classic, Timed (30s), Moves-limited, and Zen.
+- Five modes: Classic, Timed (30s), Moves-limited, Zen, and Daily challenge.
 - Keyboard-accessible SVG board and simple in-browser level editor.
 - Hint button shows next edge of Euler trail.
-- Music, SFX, and theme toggles in the HUD with persistence.
+- Music, SFX, theme, mode, locale, and progress persist via local storage.
 - Dynamic difficulty rating adjusts hint availability delay.
 - `levels/levels.json` – sample level definitions.
 - `i18n/en.json` – strings.
@@ -38,4 +38,5 @@ Each level entry:
 This repository remains a minimal prototype and does not meet the full studio specification.
 codex/develop-studio-quality-one-line-draw-game
 This repository remains a minimal prototype and does not meet the full studio specification.
-This repository contains a small subset of the full specification. Audio, advanced game modes, the level editor and many polish items are not yet implemented.
+This repository contains a small subset of the full specification. Audio, advanced game modes, the level editor and many polish
+items are not yet implemented.

--- a/game.js
+++ b/game.js
@@ -4,9 +4,10 @@ import Renderer from './src/engine/Renderer.js';
 import AudioManager from './src/engine/Audio.js';
 import { initTheme, cycleTheme } from './src/utils/Theme.js';
 import { loadRating, saveRating, updateRating, getHintDelay } from './src/progress/Rating.js';
-import Renderer from './src/engine/Renderer.js';
-
-const i18n = await fetch('./i18n/en.json').then(r => r.json());
+import * as Storage from './src/progress/Storage.ts';
+const locale = Storage.getLocale();
+Storage.setLocale(locale);
+const i18n = await fetch(`./i18n/${locale}.json`).then(r => r.json());
 const levels = await fetch('./levels/levels.json').then(r => r.json());
 
 const preloader = document.getElementById('preloader');
@@ -45,11 +46,14 @@ hintBtn.title = i18n.hint;
 hintBtn.setAttribute('aria-label', i18n.hint);
 toggleMusicBtn.classList.toggle('off', !audio.enabled.music);
 toggleSfxBtn.classList.toggle('off', !audio.enabled.sfx);
+
+modeSelect.value = Storage.getMode();
 let currentTheme = initTheme();
 
-let levelIndex = 0;
+let levelIndex = Storage.getCurrentLevel();
 let hearts = 3;
-let mode = 'classic';
+let initialHearts = 3;
+let mode = Storage.getMode();
 let timer = 0;
 let moves = 0;
 let timerId;
@@ -59,24 +63,20 @@ let solutionEdges = [];
 let currentNode = null;
 const visitedEdges = new Set();
 let rating = loadRating();
-let graph, renderer;
-let solutionEdges = [];
-const gameEl = document.getElementById('game');
-const board = document.getElementById('board');
-const heartsEl = document.getElementById('hearts');
-
-startBtn.textContent = i18n.start;
-document.querySelector('#title h1').textContent = i18n.title;
-
-let levelIndex = 0;
-let hearts = 3;
-let graph, renderer;
-let currentNode = null;
-const visitedEdges = new Set();
+let dailyDate = null;
 
 function showTitle() {
   preloader.classList.add('hidden');
   title.classList.remove('hidden');
+}
+
+function getDailyChallenge() {
+  const date = new Date().toISOString().slice(0,10);
+  let hash = 0;
+  for (const c of date) {
+    hash = (hash * 31 + c.charCodeAt(0)) % levels.length;
+  }
+  return { index: hash, date };
 }
 
 function startGame() {
@@ -85,17 +85,27 @@ function startGame() {
   audio.init();
   audio.startMusic();
   mode = modeSelect.value;
+  Storage.setMode(mode);
+  if (mode === 'daily') {
+    const daily = getDailyChallenge();
+    levelIndex = daily.index;
+    dailyDate = daily.date;
+  } else {
+    levelIndex = Storage.getCurrentLevel();
+    dailyDate = null;
+  }
   loadLevel(levelIndex);
 }
 
 function loadLevel(idx) {
   const data = levels[idx];
-  hearts = data.hearts || 3;
+  initialHearts = data.hearts || 3;
+  hearts = initialHearts;
   timer = 30;
   moves = data.edges.length * 2;
   clearInterval(timerId);
   clearTimeout(hintTimerId);
-  if (mode === 'timed') {
+  if (mode === 'timed' || mode === 'daily') {
     timerId = setInterval(() => {
       timer--;
       metaEl.textContent = `⏱ ${timer}`;
@@ -122,11 +132,7 @@ function loadLevel(idx) {
   hintTimerId = setTimeout(() => {
     hintBtn.disabled = false;
   }, getHintDelay(rating));
-  heartsEl.textContent = '❤'.repeat(hearts);
-  graph = new Graph(data.nodes, data.edges);
-  renderer = new Renderer(board, graph);
-  currentNode = null;
-  visitedEdges.clear();
+  if (mode !== 'daily') Storage.setCurrentLevel(idx);
 }
 
 function showModal(text, btnText, cb) {
@@ -148,10 +154,6 @@ function handleNodeClick(e) {
   const idx = parseInt(target.getAttribute('data-index'), 10);
   if (currentNode === null) {
     currentNode = idx;
-    target.classList.add('active');
-  } else if (currentNode === idx) {
-    target.classList.remove('active');
-    currentNode = null;
   } else {
     if (graph.edgeExists(currentNode, idx)) {
       const key = `${Math.min(currentNode, idx)}-${Math.max(currentNode, idx)}`;
@@ -206,19 +208,6 @@ function handleHint() {
     if (!visitedEdges.has(key)) {
       renderer.highlightEdge(a, b);
       return;
-        hearts--;
-        heartsEl.textContent = '❤'.repeat(hearts);
-        if (hearts <= 0) return gameOver();
-      } else {
-        visitedEdges.add(key);
-        renderer.markEdge(currentNode, idx);
-        currentNode = idx;
-        if (visitedEdges.size === graph.edges.length) return levelComplete();
-      }
-    } else {
-      hearts--;
-      heartsEl.textContent = '❤'.repeat(hearts);
-      if (hearts <= 0) return gameOver();
     }
   }
 }
@@ -226,21 +215,38 @@ function handleHint() {
 function levelComplete() {
   clearInterval(timerId);
   audio.play('complete');
-  rating = updateRating(rating, true);
-  saveRating(rating);
-  showModal(i18n.levelComplete, i18n.next, () => {
-    levelIndex = (levelIndex + 1) % levels.length;
-    loadLevel(levelIndex);
-  });
+  if (mode === 'daily') {
+    Storage.updateDaily(dailyDate, {
+      solved: true,
+      perfect: hearts === initialHearts,
+      gold: timer >= 20
+    });
+    showModal(i18n.dailyComplete || i18n.levelComplete, i18n.retry, () => {
+      loadLevel(levelIndex);
+    });
+  } else {
+    rating = updateRating(rating, true);
+    saveRating(rating);
+    Storage.updateBestStats(levelIndex, { hearts, time: timer });
+    Storage.unlockLevel((levelIndex + 1) % levels.length);
+    showModal(i18n.levelComplete, i18n.next, () => {
+      levelIndex = (levelIndex + 1) % levels.length;
+      Storage.setCurrentLevel(levelIndex);
+      loadLevel(levelIndex);
+    });
+  }
 }
 
 function gameOver() {
   clearInterval(timerId);
   audio.play('fail');
-  rating = updateRating(rating, false);
-  saveRating(rating);
-  showModal(i18n.gameOver, i18n.retry, () => {
+  if (mode !== 'daily') {
+    rating = updateRating(rating, false);
+    saveRating(rating);
     levelIndex = 0;
+    Storage.setCurrentLevel(levelIndex);
+  }
+  showModal(i18n.gameOver, i18n.retry, () => {
     loadLevel(levelIndex);
   });
 }
@@ -248,6 +254,9 @@ function gameOver() {
 board.addEventListener('click', handleNodeClick);
 board.addEventListener('keydown', handleKey);
 startBtn.addEventListener('click', startGame);
+modeSelect.addEventListener('change', () => {
+  Storage.setMode(modeSelect.value);
+});
 toggleMusicBtn.addEventListener('click', () => {
   const on = audio.toggle('music');
   toggleMusicBtn.classList.toggle('off', !on);
@@ -260,18 +269,5 @@ hintBtn.addEventListener('click', handleHint);
 toggleThemeBtn.addEventListener('click', () => {
   currentTheme = cycleTheme(currentTheme);
 });
-  alert(i18n.levelComplete);
-  levelIndex = (levelIndex + 1) % levels.length;
-  loadLevel(levelIndex);
-}
-
-function gameOver() {
-  alert(i18n.gameOver);
-  levelIndex = 0;
-  loadLevel(levelIndex);
-}
-
-board.addEventListener('click', handleNodeClick);
-startBtn.addEventListener('click', startGame);
 
 setTimeout(showTitle, 700);

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9,6 +9,7 @@
   "sfx": "SFX",
   "editor": "Editor",
   "hint": "Hint",
-  "theme": "Theme"
-  "retry": "Retry"
+  "theme": "Theme",
+  "dailyComplete": "Daily Complete",
+  "daily": "Daily"
 }

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       <option value="classic">Classic</option>
       <option value="timed">Timed</option>
       <option value="moves">Moves</option>
+      <option value="daily">Daily</option>
       <option value="zen">Zen</option>
     </select>
     <button id="startBtn"></button>

--- a/src/engine/Audio.js
+++ b/src/engine/Audio.js
@@ -1,9 +1,11 @@
+import { getAudio, setAudio } from '../progress/Storage.ts';
+
 export default class AudioManager {
   constructor() {
     this.ctx = null;
     this.musicOsc = null;
     this.musicGain = null;
-    const saved = JSON.parse(localStorage.getItem('audio') || '{}');
+    const saved = getAudio();
     this.enabled = {
       music: saved.music !== undefined ? saved.music : true,
       sfx: saved.sfx !== undefined ? saved.sfx : true,
@@ -20,7 +22,7 @@ export default class AudioManager {
   }
 
   save() {
-    localStorage.setItem('audio', JSON.stringify(this.enabled));
+    setAudio(this.enabled);
   }
 
   toggle(type) {

--- a/src/progress/Storage.ts
+++ b/src/progress/Storage.ts
@@ -1,0 +1,134 @@
+const KEY = 'onelinedraw_progress';
+const storage = typeof localStorage !== 'undefined' ? localStorage : null;
+const defaults = {
+  currentLevel: 0,
+  unlockedLevels: [0],
+  bestStats: {},
+  mode: 'classic',
+  theme: 'dark',
+  audio: { music: true, sfx: true },
+  locale: 'en',
+  daily: {}
+};
+
+function read() {
+  if (!storage) return { ...defaults };
+  try {
+    const raw = storage.getItem(KEY);
+    if (!raw) return { ...defaults };
+    return { ...defaults, ...JSON.parse(raw) };
+  } catch {
+    return { ...defaults };
+  }
+}
+
+function write(data) {
+  if (storage) storage.setItem(KEY, JSON.stringify(data));
+}
+
+export function getTheme() {
+  return read().theme;
+}
+
+export function setTheme(theme) {
+  const data = read();
+  data.theme = theme;
+  write(data);
+}
+
+export function getAudio() {
+  return read().audio;
+}
+
+export function setAudio(audio) {
+  const data = read();
+  data.audio = audio;
+  write(data);
+}
+
+export function getMode() {
+  return read().mode;
+}
+
+export function setMode(mode) {
+  const data = read();
+  data.mode = mode;
+  write(data);
+}
+
+export function getLocale() {
+  return read().locale;
+}
+
+export function setLocale(locale) {
+  const data = read();
+  data.locale = locale;
+  write(data);
+}
+
+export function getCurrentLevel() {
+  return read().currentLevel;
+}
+
+export function setCurrentLevel(level) {
+  const data = read();
+  data.currentLevel = level;
+  write(data);
+}
+
+export function getUnlockedLevels() {
+  return read().unlockedLevels;
+}
+
+export function unlockLevel(level) {
+  const data = read();
+  if (!data.unlockedLevels.includes(level)) data.unlockedLevels.push(level);
+  write(data);
+}
+
+export function getBestStats() {
+  return read().bestStats;
+}
+
+export function updateBestStats(level, stats) {
+  const data = read();
+  const current = data.bestStats[level] || { hearts: 0, time: 0 };
+  if (stats.hearts > current.hearts) current.hearts = stats.hearts;
+  if (stats.time > current.time) current.time = stats.time;
+  data.bestStats[level] = current;
+  write(data);
+}
+
+export function getDaily(date) {
+  const data = read();
+  return data.daily[date] || { solved: false, perfect: false, gold: false };
+}
+
+export function updateDaily(date, result) {
+  const data = read();
+  const entry = data.daily[date] || { solved: false, perfect: false, gold: false };
+  if (result.solved) entry.solved = true;
+  if (result.perfect) entry.perfect = true;
+  if (result.gold) entry.gold = true;
+  data.daily[date] = entry;
+  write(data);
+}
+
+export default {
+  getTheme,
+  setTheme,
+  getAudio,
+  setAudio,
+  getMode,
+  setMode,
+  getLocale,
+  setLocale,
+  getCurrentLevel,
+  setCurrentLevel,
+  getUnlockedLevels,
+  unlockLevel,
+  getBestStats,
+  updateBestStats,
+  getDaily,
+  updateDaily
+};

--- a/src/utils/Theme.js
+++ b/src/utils/Theme.js
@@ -1,15 +1,18 @@
+import { getTheme, setTheme } from '../progress/Storage.ts';
+
 const THEMES = ['dark','light','high'];
 
 export function initTheme(){
-  const saved = localStorage.getItem('theme');
+  const saved = getTheme();
   const theme = saved && THEMES.includes(saved) ? saved : 'dark';
   document.documentElement.dataset.theme = theme;
+  if (saved !== theme) setTheme(theme);
   return theme;
 }
 
 export function cycleTheme(current){
   const next = THEMES[(THEMES.indexOf(current)+1)%THEMES.length];
   document.documentElement.dataset.theme = next;
-  localStorage.setItem('theme', next);
+  setTheme(next);
   return next;
 }


### PR DESCRIPTION
## Summary
- persist current level, unlocked levels, best stats, mode, theme, audio, locale, and daily achievements via a new storage module
- introduce date-seeded daily challenge with first solve, perfect hearts, and timed gold tracking
- wire theme and audio toggles to shared storage and document new daily mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27c964570832c99d0ce7241a1e861