### PR TITLE
feat: enhance audio with buffered assets and sliders

### DIFF
--- a/game.js
+++ b/game.js
@@ -22,6 +22,8 @@ const toggleMusicBtn = document.getElementById('toggleMusic');
 const toggleSfxBtn = document.getElementById('toggleSfx');
 const toggleThemeBtn = document.getElementById('toggleTheme');
 const hintBtn = document.getElementById('hintBtn');
+const musicSlider = document.getElementById('musicSlider');
+const sfxSlider = document.getElementById('sfxSlider');
 const modal = document.getElementById('modal');
 const modalText = document.getElementById('modalText');
 const modalBtn = document.getElementById('modalBtn');
@@ -42,9 +44,16 @@ toggleSfxBtn.setAttribute('aria-label', i18n.sfx);
 toggleThemeBtn.setAttribute('aria-label', i18n.theme || 'Theme');
 hintBtn.textContent = i18n.hint;
 hintBtn.title = i18n.hint;
-hintBtn.setAttribute('aria-label', i18n.hint);
-toggleMusicBtn.classList.toggle('off', !audio.enabled.music);
-toggleSfxBtn.classList.toggle('off', !audio.enabled.sfx);
+ hintBtn.setAttribute('aria-label', i18n.hint);
+ musicSlider.value = audio.volume.music;
+ sfxSlider.value = audio.volume.sfx;
+function updateAudioButtons() {
+  toggleMusicBtn.textContent = audio.enabled.music ? '🎵' : '🔇';
+  toggleSfxBtn.textContent = audio.enabled.sfx ? '🔊' : '🔇';
+  toggleMusicBtn.classList.toggle('off', !audio.enabled.music);
+  toggleSfxBtn.classList.toggle('off', !audio.enabled.sfx);
+}
+updateAudioButtons();
 let currentTheme = initTheme();
 
 let levelIndex = 0;
@@ -133,9 +142,11 @@ function showModal(text, btnText, cb) {
   modalText.textContent = text;
   modalBtn.textContent = btnText;
   modal.classList.remove('hidden');
+  audio.duck(true);
   const handler = () => {
     modal.classList.add('hidden');
     modalBtn.removeEventListener('click', handler);
+    audio.duck(false);
     cb();
   };
   modalBtn.addEventListener('click', handler, { once: true });
@@ -249,29 +260,22 @@ board.addEventListener('click', handleNodeClick);
 board.addEventListener('keydown', handleKey);
 startBtn.addEventListener('click', startGame);
 toggleMusicBtn.addEventListener('click', () => {
-  const on = audio.toggle('music');
-  toggleMusicBtn.classList.toggle('off', !on);
+  audio.toggle('music');
+  updateAudioButtons();
 });
 toggleSfxBtn.addEventListener('click', () => {
-  const on = audio.toggle('sfx');
-  toggleSfxBtn.classList.toggle('off', !on);
+  audio.toggle('sfx');
+  updateAudioButtons();
+});
+musicSlider.addEventListener('input', e => {
+  audio.setVolume('music', parseFloat(e.target.value));
+});
+sfxSlider.addEventListener('input', e => {
+  audio.setVolume('sfx', parseFloat(e.target.value));
 });
 hintBtn.addEventListener('click', handleHint);
 toggleThemeBtn.addEventListener('click', () => {
   currentTheme = cycleTheme(currentTheme);
 });
-  alert(i18n.levelComplete);
-  levelIndex = (levelIndex + 1) % levels.length;
-  loadLevel(levelIndex);
-}
-
-function gameOver() {
-  alert(i18n.gameOver);
-  levelIndex = 0;
-  loadLevel(levelIndex);
-}
-
-board.addEventListener('click', handleNodeClick);
-startBtn.addEventListener('click', startGame);
 
 setTimeout(showTitle, 700);

--- a/index.html
+++ b/index.html
@@ -32,6 +32,10 @@
       <button id="toggleMusic" aria-label="Toggle Music"></button>
       <button id="toggleSfx" aria-label="Toggle SFX"></button>
       <button id="toggleTheme" aria-label="Toggle Theme"></button>
+      <label for="musicSlider" class="visually-hidden">Music Volume</label>
+      <input id="musicSlider" type="range" min="0" max="1" step="0.01">
+      <label for="sfxSlider" class="visually-hidden">SFX Volume</label>
+      <input id="sfxSlider" type="range" min="0" max="1" step="0.01">
       <button id="hintBtn" aria-label="Hint"></button>
     </div>
     <svg id="board" tabindex="0"></svg>

--- a/src/engine/Audio.js
+++ b/src/engine/Audio.js
@@ -1,78 +1,118 @@
+import { load, save } from '../progress/Storage.ts';
+
+const FILES = {
+  music: 'assets/music.mp3',
+  connect: 'assets/connect.wav',
+  fail: 'assets/fail.wav',
+  complete: 'assets/complete.wav',
+};
+
 export default class AudioManager {
   constructor() {
     this.ctx = null;
-    this.musicOsc = null;
+    this.buffers = {};
+    this.musicSource = null;
     this.musicGain = null;
-    const saved = JSON.parse(localStorage.getItem('audio') || '{}');
-    this.enabled = {
-      music: saved.music !== undefined ? saved.music : true,
-      sfx: saved.sfx !== undefined ? saved.sfx : true,
-    };
+    this.sfxGain = null;
+    this.duckGain = null;
+    const saved = load('audio', {
+      enabled: { music: true, sfx: true },
+      volume: { music: 1, sfx: 1 },
+    });
+    this.enabled = saved.enabled;
+    this.volume = saved.volume;
   }
 
   init() {
-    if (!this.ctx) {
-      const AudioCtx = window.AudioContext || window.webkitAudioContext;
-      if (AudioCtx) {
-        this.ctx = new AudioCtx();
-      }
-    }
+    if (this.ctx) return;
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (!AudioCtx) return;
+    this.ctx = new AudioCtx();
+    this.musicGain = this.ctx.createGain();
+    this.sfxGain = this.ctx.createGain();
+    this.duckGain = this.ctx.createGain();
+    this.duckGain.gain.value = 1;
+    this.musicGain.connect(this.duckGain).connect(this.ctx.destination);
+    this.sfxGain.connect(this.ctx.destination);
+    this.setVolume('music', this.volume.music);
+    this.setVolume('sfx', this.volume.sfx);
+  }
+
+  async loadBuffer(name) {
+    if (this.buffers[name]) return this.buffers[name];
+    const file = FILES[name];
+    if (!file || !this.ctx) return null;
+    const res = await fetch(file);
+    const arr = await res.arrayBuffer();
+    const buf = await this.ctx.decodeAudioData(arr);
+    this.buffers[name] = buf;
+    return buf;
   }
 
   save() {
-    localStorage.setItem('audio', JSON.stringify(this.enabled));
+    save('audio', { enabled: this.enabled, volume: this.volume });
   }
 
   toggle(type) {
     this.enabled[type] = !this.enabled[type];
-    this.save();
+    this.setVolume(type, this.volume[type]);
     if (type === 'music') {
       if (this.enabled.music) this.startMusic();
       else this.stopMusic();
     }
+    this.save();
     return this.enabled[type];
   }
 
-  startMusic() {
-    if (!this.ctx || !this.enabled.music || this.musicOsc) return;
-    const osc = this.ctx.createOscillator();
-    const gain = this.ctx.createGain();
-    osc.frequency.value = 110; // mellow tone
-    gain.gain.value = 0.05;
-    osc.connect(gain).connect(this.ctx.destination);
-    osc.start();
-    this.musicOsc = osc;
-    this.musicGain = gain;
+  setVolume(type, val) {
+    this.volume[type] = val;
+    if (type === 'music' && this.musicGain) {
+      this.musicGain.gain.value = this.enabled.music ? val : 0;
+    } else if (type === 'sfx' && this.sfxGain) {
+      this.sfxGain.gain.value = this.enabled.sfx ? val : 0;
+    }
+    this.save();
+  }
+
+  duck(on) {
+    if (!this.duckGain || !this.ctx) return;
+    const target = on ? 0.3 : 1;
+    this.duckGain.gain.cancelScheduledValues(this.ctx.currentTime);
+    this.duckGain.gain.linearRampToValueAtTime(target, this.ctx.currentTime + 0.1);
+  }
+
+  async startMusic() {
+    if (!this.enabled.music) return;
+    this.init();
+    if (!this.ctx || this.musicSource) return;
+    await this.ctx.resume();
+    const buffer = await this.loadBuffer('music');
+    if (!buffer) return;
+    const src = this.ctx.createBufferSource();
+    src.buffer = buffer;
+    src.loop = true;
+    src.connect(this.musicGain);
+    src.start();
+    this.musicSource = src;
   }
 
   stopMusic() {
-    if (this.musicOsc) {
-      this.musicOsc.stop();
-      this.musicOsc.disconnect();
-      this.musicOsc = null;
+    if (this.musicSource) {
+      this.musicSource.stop();
+      this.musicSource.disconnect();
+      this.musicSource = null;
     }
   }
 
-  play(type) {
-    if (!this.ctx || !this.enabled.sfx) return;
-    const osc = this.ctx.createOscillator();
-    const gain = this.ctx.createGain();
-    let freq = 440;
-    switch (type) {
-      case 'fail':
-        freq = 220;
-        break;
-      case 'complete':
-        freq = 660;
-        break;
-      default:
-        freq = 440;
-    }
-    osc.frequency.value = freq;
-    osc.connect(gain).connect(this.ctx.destination);
-    gain.gain.setValueAtTime(0.2, this.ctx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.001, this.ctx.currentTime + 0.1);
-    osc.start();
-    osc.stop(this.ctx.currentTime + 0.1);
+  async play(type) {
+    if (!this.enabled.sfx) return;
+    this.init();
+    if (!this.ctx) return;
+    const buffer = await this.loadBuffer(type);
+    if (!buffer) return;
+    const src = this.ctx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(this.sfxGain);
+    src.start();
   }
 }

--- a/src/progress/Storage.ts
+++ b/src/progress/Storage.ts
@@ -1,0 +1,20 @@
+const storage = typeof localStorage !== 'undefined' ? localStorage : null;
+
+export function load(key, fallback) {
+  if (!storage) return fallback;
+  try {
+    const raw = storage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function save(key, value) {
+  if (!storage) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // ignore
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -121,3 +121,5 @@ body{
 .edge.path{stroke:#964B00;}
 .node{fill:#fff;stroke:#000;stroke-width:2;cursor:pointer;}
 .node.active{fill:#ff0;}
+
+.hud input[type="range"]{width:80px;margin-left:10px;}


### PR DESCRIPTION
## Summary
- replace oscillator placeholders with buffered audio assets and gain buses
- add volume sliders with persistence and modal ducking
- expose mute state icons and delay music until user starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a27c9226e4832c81aa27809b1556fb