### PR TITLE
feat: add loop with input recording

### DIFF
--- a/src/engine/Input.js
+++ b/src/engine/Input.js
@@ -1,0 +1,50 @@
+export default class Input {
+  constructor() {
+    this.queue = [];
+    this.recording = null;
+    this.playback = null;
+    this.playbackIndex = 0;
+  }
+
+  capture(event) {
+    this.queue.push(event);
+  }
+
+  poll(frame) {
+    const events = this.queue;
+    this.queue = [];
+    if (this.recording) {
+      for (const e of events) this.recording.push({ frame, event: e });
+    }
+    if (this.playback) {
+      while (
+        this.playbackIndex < this.playback.length &&
+        this.playback[this.playbackIndex].frame === frame
+      ) {
+        events.push(this.playback[this.playbackIndex].event);
+        this.playbackIndex++;
+      }
+    }
+    return events;
+  }
+
+  startRecording() {
+    this.recording = [];
+  }
+
+  stopRecording() {
+    const rec = this.recording || [];
+    this.recording = null;
+    return rec.slice();
+  }
+
+  startPlayback(recording) {
+    this.playback = recording.slice();
+    this.playbackIndex = 0;
+  }
+
+  stopPlayback() {
+    this.playback = null;
+    this.playbackIndex = 0;
+  }
+}

--- a/src/engine/Input.ts
+++ b/src/engine/Input.ts
@@ -1,0 +1,53 @@
+interface RecordedEvent<T=any> {
+  frame: number;
+  event: T;
+}
+
+export default class Input<T=any> {
+  private queue: T[] = [];
+  private recording: RecordedEvent<T>[] | null = null;
+  private playback: RecordedEvent<T>[] | null = null;
+  private playbackIndex = 0;
+
+  capture(event: T) {
+    this.queue.push(event);
+  }
+
+  poll(frame: number): T[] {
+    const events = this.queue;
+    this.queue = [];
+    if (this.recording) {
+      for (const e of events) this.recording.push({ frame, event: e });
+    }
+    if (this.playback) {
+      while (
+        this.playbackIndex < this.playback.length &&
+        this.playback[this.playbackIndex].frame === frame
+      ) {
+        events.push(this.playback[this.playbackIndex].event);
+        this.playbackIndex++;
+      }
+    }
+    return events;
+  }
+
+  startRecording() {
+    this.recording = [];
+  }
+
+  stopRecording(): RecordedEvent<T>[] {
+    const rec = this.recording || [];
+    this.recording = null;
+    return rec.slice();
+  }
+
+  startPlayback(recording: RecordedEvent<T>[]) {
+    this.playback = recording.slice();
+    this.playbackIndex = 0;
+  }
+
+  stopPlayback() {
+    this.playback = null;
+    this.playbackIndex = 0;
+  }
+}

--- a/src/engine/Loop.js
+++ b/src/engine/Loop.js
@@ -1,0 +1,44 @@
+import Input from './Input.js';
+
+export default class Loop {
+  constructor(opts) {
+    this.update = opts.update;
+    this.render = opts.render || (() => {});
+    this.input = opts.input || null;
+    this.running = false;
+    this.frame = 0;
+    this.last = 0;
+    this.accumulator = 0;
+    this.step = 1000 / 120;
+    this.boundTick = this.tick.bind(this);
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this.last = performance.now();
+    requestAnimationFrame(this.boundTick);
+  }
+
+  stop() {
+    this.running = false;
+  }
+
+  tick(time) {
+    if (!this.running) return;
+    this.accumulator += time - this.last;
+    this.last = time;
+    while (this.accumulator >= this.step) {
+      this.stepFrame();
+      this.accumulator -= this.step;
+    }
+    this.render();
+    requestAnimationFrame(this.boundTick);
+  }
+
+  stepFrame() {
+    this.frame++;
+    const events = this.input ? this.input.poll(this.frame) : [];
+    this.update(events, this.step);
+  }
+}

--- a/src/engine/Loop.ts
+++ b/src/engine/Loop.ts
@@ -1,0 +1,52 @@
+import Input from './Input.js';
+
+type UpdateFn = (events: any[], dt: number) => void;
+type RenderFn = () => void;
+
+export default class Loop {
+  private update: UpdateFn;
+  private render: RenderFn;
+  private input: Input | null;
+  private running = false;
+  private frame = 0;
+  private last = 0;
+  private accumulator = 0;
+  private readonly step = 1000 / 120;
+  private readonly boundTick: FrameRequestCallback;
+
+  constructor(opts: { update: UpdateFn; render?: RenderFn; input?: Input }) {
+    this.update = opts.update;
+    this.render = opts.render || (() => {});
+    this.input = opts.input || null;
+    this.boundTick = this.tick.bind(this);
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this.last = performance.now();
+    requestAnimationFrame(this.boundTick);
+  }
+
+  stop() {
+    this.running = false;
+  }
+
+  private tick(time: number) {
+    if (!this.running) return;
+    this.accumulator += time - this.last;
+    this.last = time;
+    while (this.accumulator >= this.step) {
+      this.stepFrame();
+      this.accumulator -= this.step;
+    }
+    this.render();
+    requestAnimationFrame(this.boundTick);
+  }
+
+  stepFrame() {
+    this.frame++;
+    const events = this.input ? this.input.poll(this.frame) : [];
+    this.update(events, this.step);
+  }
+}

--- a/src/engine/State.js
+++ b/src/engine/State.js
@@ -1,0 +1,20 @@
+export default class State {
+  constructor() {
+    this.handlers = new Map();
+  }
+
+  on(type, handler) {
+    this.handlers.set(type, handler);
+  }
+
+  off(type) {
+    this.handlers.delete(type);
+  }
+
+  update(events) {
+    for (const e of events) {
+      const handler = this.handlers.get(e.type);
+      if (handler) handler(e);
+    }
+  }
+}

--- a/src/engine/State.ts
+++ b/src/engine/State.ts
@@ -1,0 +1,20 @@
+export type Handler<T=any> = (event: T) => void;
+
+export default class State<T=any> {
+  private handlers: Map<string, Handler<T>> = new Map();
+
+  on(type: string, handler: Handler<T>) {
+    this.handlers.set(type, handler);
+  }
+
+  off(type: string) {
+    this.handlers.delete(type);
+  }
+
+  update(events: any[]) {
+    for (const e of events) {
+      const handler = this.handlers.get(e.type);
+      if (handler) handler(e);
+    }
+  }
+}

--- a/src/ui/UI.js
+++ b/src/ui/UI.js
@@ -1,0 +1,19 @@
+import EventBus from '../utils/EventBus.js';
+
+export default class UI {
+  constructor(bus) {
+    this.bus = bus;
+  }
+
+  bindButton(el, event) {
+    el.addEventListener('click', () => this.bus.emit(event));
+  }
+
+  show(el) {
+    el.classList.remove('hidden');
+  }
+
+  hide(el) {
+    el.classList.add('hidden');
+  }
+}

--- a/src/ui/UI.ts
+++ b/src/ui/UI.ts
@@ -1,0 +1,20 @@
+import EventBus from '../utils/EventBus.js';
+
+export default class UI {
+  private bus: EventBus;
+  constructor(bus: EventBus) {
+    this.bus = bus;
+  }
+
+  bindButton(el: HTMLElement, event: string) {
+    el.addEventListener('click', () => this.bus.emit(event));
+  }
+
+  show(el: HTMLElement) {
+    el.classList.remove('hidden');
+  }
+
+  hide(el: HTMLElement) {
+    el.classList.add('hidden');
+  }
+}

--- a/src/utils/EventBus.js
+++ b/src/utils/EventBus.js
@@ -1,0 +1,40 @@
+export default class EventBus {
+  constructor() {
+    this.listeners = new Map();
+  }
+
+  on(event, handler) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event).add(handler);
+    return () => this.off(event, handler);
+  }
+
+  off(event, handler) {
+    const set = this.listeners.get(event);
+    if (set) {
+      set.delete(handler);
+      if (set.size === 0) this.listeners.delete(event);
+    }
+  }
+
+  emit(event, data) {
+    const set = this.listeners.get(event);
+    if (set) {
+      for (const handler of Array.from(set)) handler(data);
+    }
+  }
+
+  once(event, handler) {
+    const wrapper = (data) => {
+      this.off(event, wrapper);
+      handler(data);
+    };
+    this.on(event, wrapper);
+  }
+
+  clear() {
+    this.listeners.clear();
+  }
+}

--- a/src/utils/EventBus.ts
+++ b/src/utils/EventBus.ts
@@ -1,0 +1,38 @@
+export default class EventBus {
+  private listeners: Map<string, Set<Function>> = new Map();
+
+  on(event: string, handler: Function) {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler);
+    return () => this.off(event, handler);
+  }
+
+  off(event: string, handler: Function) {
+    const set = this.listeners.get(event);
+    if (set) {
+      set.delete(handler);
+      if (set.size === 0) this.listeners.delete(event);
+    }
+  }
+
+  emit(event: string, data?: any) {
+    const set = this.listeners.get(event);
+    if (set) {
+      for (const handler of Array.from(set)) handler(data);
+    }
+  }
+
+  once(event: string, handler: Function) {
+    const wrapper = (data: any) => {
+      this.off(event, wrapper);
+      handler(data);
+    };
+    this.on(event, wrapper);
+  }
+
+  clear() {
+    this.listeners.clear();
+  }
+}

--- a/tests/eventbus.test.js
+++ b/tests/eventbus.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import EventBus from '../src/utils/EventBus.js';
+
+test('EventBus emits and removes listeners', () => {
+  const bus = new EventBus();
+  let called = 0;
+  const handler = (v) => { called += v; };
+  bus.on('add', handler);
+  bus.emit('add', 2);
+  assert.equal(called, 2);
+  bus.off('add', handler);
+  bus.emit('add', 2);
+  assert.equal(called, 2);
+});

--- a/tests/loop.test.js
+++ b/tests/loop.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Input from '../src/engine/Input.js';
+import State from '../src/engine/State.js';
+import Loop from '../src/engine/Loop.js';
+
+test('recorded input replays deterministically', () => {
+  const input = new Input();
+  const state = new State();
+  state.on('move', (e) => { state.pos = (state.pos || 0) + e.value; });
+  const loop = new Loop({ update: (events) => state.update(events), input });
+
+  input.startRecording();
+  input.capture({ type: 'move', value: 1 });
+  loop.stepFrame(); // frame1
+  loop.stepFrame(); // frame2 no input
+  input.capture({ type: 'move', value: -1 });
+  loop.stepFrame(); // frame3
+  const record = input.stopRecording();
+  const final = state.pos;
+
+  // replay
+  const replayInput = new Input();
+  const replayState = new State();
+  replayState.on('move', (e) => { replayState.pos = (replayState.pos || 0) + e.value; });
+  const replayLoop = new Loop({ update: (ev) => replayState.update(ev), input: replayInput });
+  replayInput.startPlayback(record);
+  replayLoop.stepFrame();
+  replayLoop.stepFrame();
+  replayLoop.stepFrame();
+
+  assert.equal(replayState.pos, final);
+});


### PR DESCRIPTION
## Summary
- add lightweight event bus and UI helpers
- implement input queue with deterministic record/replay
- create fixed 120Hz game loop
- cover event bus and record/replay via tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a27c8d93cc832c88cb29afc6e3693b